### PR TITLE
handle missing file /tmp/ip-record

### DIFF
--- a/cloudflare-ddns.sh
+++ b/cloudflare-ddns.sh
@@ -8,7 +8,7 @@ A_RECORD_ID=** CF A-record ID from cloudflare-dns-id.sh **
 
 # Retrieve the last recorded public IP address
 IP_RECORD="/tmp/ip-record"
-RECORDED_IP=`cat $IP_RECORD`
+RECORDED_IP=$(cat $IP_RECORD) || true
 
 # Fetch the current public IP address
 PUBLIC_IP=$(curl --silent https://api.ipify.org) || exit 1


### PR DESCRIPTION
The first time I run this script, it fails at line 11 because the file `/tmp/ip-record` doesn't exist. This solves the problem by substituting the empty string, and forcing the exit status of line 11 to always be `0`.